### PR TITLE
ci: remove Windows 2019 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,6 @@ jobs:
           - os: windows-2022
             elixir-version: '1.18.4'
             otp-version: '28.0.1'
-          - os: windows-2019
-            elixir-version: '1.18.4'
-            otp-version: '28.0.1'
 
     name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
     needs: build-and-test-latest

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ be found at <https://hexdocs.pm/get_host>.
 * Ubuntu 22.04 / Elixir 1.15 / OTP 25
 * Windows 2022 / Elixir 1.19 / OTP 28
 * Windows 2022 / Elixir 1.18 / OTP 28
-* Windows 2019 / Elixir 1.18 / OTP 28
 
 ## License
 


### PR DESCRIPTION
- Remove Windows 2019 test matrix from CI workflow
- Update README to reflect supported platforms
- Simplify CI pipeline by focusing on current Windows 2022 runners