### PR TITLE
feat: Add macOS CI workflow support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,39 @@ jobs:
       run: mix deps.get
     - name: Run tests
       run: mix test
+
+  build-and-test-macos:
+    strategy:
+      matrix:
+        include:
+          - os: macos-14-xlarge
+            elixir-version: '1.18.4'
+            otp-version: '28.0.1'
+
+    name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
+    needs: build-and-test-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Elixir
+      uses: jdx/mise-action@v2
+      with:
+        version: '2025.7.2'
+        install: true
+        cache: true
+        experimental: true
+        log_level: debug
+        tool_versions: |
+            erlang: ${{ matrix.otp-version }}
+            elixir: ${{ matrix.elixir-version }}
+
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Run tests
+      run: mix test

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ be found at <https://hexdocs.pm/get_host>.
 * Ubuntu 22.04 / Elixir 1.15 / OTP 25
 * Windows 2022 / Elixir 1.19 / OTP 28
 * Windows 2022 / Elixir 1.18 / OTP 28
+* macOS Sonoma on Apple Silicon / Elixir 1.18 / OTP 28
 
 ## License
 

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,7 @@
     "userWords": [
         "oneshot",
         "spellweaver",
-        "nstandard"
+        "nstandard",
+        "Sonoma"
     ]
 }


### PR DESCRIPTION
- Add build-and-test-macos job to CI workflow
- Configure macOS Sonoma on Apple Silicon with Elixir 1.18.4/OTP 28.0.1
- Use jdx/mise-action@v2 for Elixir/Erlang setup on macOS
- Update README.md to include macOS platform support
- Add "Sonoma" to cspell.json userWords to prevent spell check errors